### PR TITLE
Added a constructor for drwnPartialAssignment.

### DIFF
--- a/src/lib/pgm/drwnVarAssignment.h
+++ b/src/lib/pgm/drwnVarAssignment.h
@@ -62,6 +62,14 @@ class drwnPartialAssignment : public std::map<int, int> {
         }
     }
 
+    //! construct a partial assignment from a partial assignment expressed
+    //! using a vector of variables and a vector of values
+    drwnPartialAssignment(const vector<int>& vars, const vector<int>& vals) {
+        for (int i = 0; i < vars.size(); i++) {
+            this->insert(make_pair(vars[i], vals[i]));
+        }
+    }
+
     //! return the clique of variables over which the partial
     //! assignment is defined
     drwnClique getClique() const {


### PR DESCRIPTION
Makes a partial assignment from a vector of variables and a vector of values,
suited for coordinate format (sparse factor usage).